### PR TITLE
libxslt1-dev is needed for pip install to be able to install lxml

### DIFF
--- a/manifests/classes/socorro-base.pp
+++ b/manifests/classes/socorro-base.pp
@@ -121,6 +121,10 @@ class socorro-base {
             require => Exec['apt-get-update'],
             ensure => present;
 
+        'libxslt1-dev':
+            require => Exec['apt-get-update'],
+            ensure => present;
+
         'build-essential':
             require => Exec['apt-get-update'],
             ensure => present;


### PR DESCRIPTION
I confirmed this by doing a clean destroy && up followed by make install && make test and it failed on pip install lxml (from requirements.txt)

Just running apt-get install libxslt1-dev made `make install` work. 
