### PR TITLE
fixed problem with /etc/apache2/sites-enabled/crash-stats

### DIFF
--- a/files/etc_apache2_sites-available/crash-stats
+++ b/files/etc_apache2_sites-available/crash-stats
@@ -6,13 +6,13 @@
   ReWriteEngine On
 
   RewriteCond %{REQUEST_URI} /dumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).jsonz
-  ReWriteRule /dumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).jsonz http://socorro-api/crashes/201005/crash/processed/by/uuid/$1$2$3$4 [P]
+  ReWriteRule /dumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).jsonz http://socorro-api/crashes/crash/processed/by/uuid/$1$2$3$4 [P]
 
   RewriteCond %{REQUEST_URI} /rawdumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).dump
-  ReWriteRule /rawdumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).dump http://socorro-api/crashes/201005/crash/raw_crash/by/uuid/$1$2$3$4 [P]
+  ReWriteRule /rawdumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).dump http://socorro-api/crashes/crash/raw_crash/by/uuid/$1$2$3$4 [P]
 
   RewriteCond %{REQUEST_URI} /rawdumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).json
-  ReWriteRule /rawdumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).json http://socorro-api/crashes/201005/crash/meta/by/uuid/$1$2$3$4 [P]
+  ReWriteRule /rawdumps/(\w\w)(\w\w)((?:\w|-)+?)(\d{6}).json http://socorro-api/crashes/crash/meta/by/uuid/$1$2$3$4 [P]
 
   ReWriteRule /rawdumps/(.*).(json|dump) /missing_dump [L]
 


### PR DESCRIPTION
Dear Robert!

Thank you for such rapid fixing of the problem with isodate! After some more explorations of the socorro-vagrant I noticed, that there was some problem with /etc/apache2/sites-enabled/crash-stats file: current url config in the socorro webapp did not have dispatchers of such patterns of urls. So I created this patch.

Thanks for your attention.

Konstantin Nikitin,
software engeneer.

Best regards
